### PR TITLE
Add image attribution

### DIFF
--- a/posts/raw/random/2018-01-25
+++ b/posts/raw/random/2018-01-25
@@ -38,7 +38,7 @@ So,
 [h3[]Why not add it to JavaScript as well?]
 Because, while intending otherwise, you'd be making this picture more true:
 [img[src[https://pbs.twimg.com/media/Cy4cOJuUUAA7MM5.jpg]] /]
-[small[](if anybody reading this knows who deserves credit for that drawing, let me know and I'll add it here)]
+[small[](credit to the [Leftover Salad comic](http://leftoversalad.com/c/015_programmingpeople/))]
 
 Why? Because operators in JavaScript don't work like in those neat functional languages. You can't overload (you might sort of fake it with [a[href[http://2ality.com/2011/12/fake-operator-overloading.html]]hacks like this], but please don't) or define custom operators in JS. They are also not first class citizens. Can't pass 'em as arguments or return 'em from functions.
 


### PR DESCRIPTION
This adds the proper credit for the included image. (Note, I did not confirm if the link syntax renders properly within the `small` markup, this might need to be adjusted.)